### PR TITLE
Fix name declation for version jira > 7

### DIFF
--- a/tasks/installJira.yml
+++ b/tasks/installJira.yml
@@ -10,7 +10,7 @@
 
 - name: Set download location for jira 7
   set_fact:
-     jira_archive: "atlassian-jira-software-{{ jira_version }}-jira-{{ jira_version }}.tar.gz"
+     jira_archive: "atlassian-jira-software-{{ jira_version }}.tar.gz"
   when: "{{ jira_version | version_compare('7.0.0', '>=') }}"
 
 - name: Set download location for jira 6 and lower
@@ -21,7 +21,7 @@
 - name: Download and Extract Application
   unarchive: src="{{ jira_download_location }}/{{ jira_archive }}" dest={{ jira_install_location }} owner={{ jira_user }}  group={{ jira_group }} copy=no
 
-- name: Get install path 
+- name: Get install path
   shell: ls -d {{ jira_install_location }}/atlassian-jira*
   register: full_path
 
@@ -47,12 +47,12 @@
      regexp="^JIRA_USER="
      line="JIRA_USER={{ jira_user }}"
 
-- name: Set JIRA Minimum Memory 
-  replace: dest={{ jira_install_location }}/jira/bin/setenv.sh 
-           regexp='384m' 
+- name: Set JIRA Minimum Memory
+  replace: dest={{ jira_install_location }}/jira/bin/setenv.sh
+           regexp='384m'
            replace='{{ jira_jvm_minimum_memory }}'
 
 - name: Set JIRA Maximum Memory
-  replace: dest={{ jira_install_location }}/jira/bin/setenv.sh 
-           regexp='768m' 
+  replace: dest={{ jira_install_location }}/jira/bin/setenv.sh
+           regexp='768m'
            replace='{{ jira_jvm_maximum_memory }}'


### PR DESCRIPTION
Currently the url : [https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-7.2.5.tar.gz](https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-7.2.5.tar.gz)