### PR TITLE
Legacy multi-line replaced by native yaml

### DIFF
--- a/tasks/configMysql.yml
+++ b/tasks/configMysql.yml
@@ -1,28 +1,39 @@
 ---
 - name: Download and extract Apache MYSQL connector
-  unarchive: src="{{ mysql_connector_url }}" dest={{ system_tmp }} owner={{ jira_user }} group={{ jira_group }} copy=no
+  unarchive:
+    src: "{{ mysql_connector_url }}"
+    dest: '{{ system_tmp }}'
+    owner: '{{ jira_user }}'
+    group: '{{ jira_group }}'
+    copy: no
 
 - name: Copy the connector into jira libs directory
   command: "cp {{ system_tmp }}/mysql-connector-java-{{ mysql_connector_version }}/mysql-connector-java-{{ mysql_connector_version }}-bin.jar {{ jira_install_location }}/jira/lib"
 
 - name: Create default database user for application
-  mysql_user: name={{ db_application_user }} 
-              password={{ db_application_password }} 
-              login_host={{ db_hostname }}
-              login_port={{ db_port }}
-              login_user={{ db_admin_user }} 
-              login_password={{ db_admin_password }} 
-              priv=*.*:ALL,GRANT 
-              state=present
+  mysql_user:
+    name: '{{ db_application_user }}'
+    password: '{{ db_application_password }}'
+    login_host: '{{ db_hostname }}'
+    login_port: '{{ db_port }}'
+    login_user: '{{ db_admin_user }}'
+    login_password: '{{ db_admin_password }}'
+    priv: "*.*:ALL,GRANT"
+    state: present
 
 - name: Create default database
-  mysql_db: name={{ db_name }} 
-            login_host={{ db_hostname }}
-            login_port={{ db_port }}
-            login_user={{ db_admin_user }} 
-            login_password={{ db_admin_password }} 
-            encoding=utf8
-            state=present
+  mysql_db:
+    name: '{{ db_name }}'
+    login_host: '{{ db_hostname }}'
+    login_port: '{{ db_port }}'
+    login_user: '{{ db_admin_user }}'
+    login_password: '{{ db_admin_password }}'
+    encoding: utf8
+    state: present
 
 - name: Configure application to use mysql
-  template: src=templates/mysql_dbconfig.xml.j2 dest={{ jira_application_home }}/jira/dbconfig.xml owner={{ jira_user }} group={{ jira_group }}
+  template:
+    src: templates/mysql_dbconfig.xml.j2
+    dest: '{{ jira_application_home }}/jira/dbconfig.xml'
+    owner: '{{ jira_user }}'
+    group: '{{ jira_group }}'

--- a/tasks/configPostgres.yml
+++ b/tasks/configPostgres.yml
@@ -1,23 +1,29 @@
 ---
 - name: Create default database
-  postgresql_db: name={{ db_name }}
-                 login_host={{ db_hostname }}
-                 login_port={{ db_port }}
-                 login_user={{ db_admin_user }}
-                 login_password={{ db_admin_password }}
-                 encoding=utf8
-                 state=present
+  postgresql_db:
+    name: '{{ db_name }}'
+    login_host: '{{ db_hostname }}'
+    login_port: '{{ db_port }}'
+    login_user: '{{ db_admin_user }}'
+    login_password: '{{ db_admin_password }}'
+    encoding: utf8
+    state: present
 
 - name: Create default database user for application
-  postgresql_user: db={{ db_name }}  
-                   name={{ db_application_user }} 
-                   password={{ db_application_password }} 
-                   login_host={{ db_hostname }}
-                   login_port={{ db_port }}
-                   login_user={{ db_admin_user }} 
-                   login_password={{ db_admin_password }} 
-                   priv=ALL
-                   state=present
+  postgresql_user:
+    db: '{{ db_name }}'
+    name: '{{ db_application_user }}'
+    password: '{{ db_application_password }}'
+    login_host: '{{ db_hostname }}'
+    login_port: '{{ db_port }}'
+    login_user: '{{ db_admin_user }}'
+    login_password: '{{ db_admin_password }}'
+    priv: ALL
+    state: present
 
 - name: Configure application to use postgres
-  template: src=templates/postgres_dbconfig.xml.j2 dest={{ jira_application_home }}/jira/dbconfig.xml owner={{ jira_user }} group={{ jira_group }}
+  template:
+    src: templates/postgres_dbconfig.xml.j2
+    dest: '{{ jira_application_home }}/jira/dbconfig.xml'
+    owner: '{{ jira_user }}'
+    group: '{{ jira_group }}'

--- a/tasks/installJira.yml
+++ b/tasks/installJira.yml
@@ -1,12 +1,23 @@
 ---
 - name: Ensure {{ jira_group }} group exists
-  group: name={{ jira_group }}  state=present system=yes
+  group:
+    name: '{{ jira_group }}'
+    state: present
+    system: yes
 
 - name: Ensure {{ jira_user }} user exists
-  user: name={{ jira_user }} group={{ jira_group }} state=present system=yes
+  user:
+    name: '{{ jira_user }}'
+    group: '{{ jira_group }}'
+    state: present
+    system: yes
 
 - name: Create installation directory
-  file: path={{ jira_install_location }} state=directory owner={{ jira_user }}  group={{ jira_group }}
+  file:
+    path: '{{ jira_install_location }}'
+    state: directory
+    owner: '{{ jira_user }}'
+    group: '{{ jira_group }}'
 
 - name: Set download location for jira 7
   set_fact:
@@ -19,7 +30,12 @@
   when: "{{ jira_version | version_compare('7.0.0', '<') }}"
 
 - name: Download and Extract Application
-  unarchive: src="{{ jira_download_location }}/{{ jira_archive }}" dest={{ jira_install_location }} owner={{ jira_user }}  group={{ jira_group }} copy=no
+  unarchive:
+    src: "{{ jira_download_location }}/{{ jira_archive }}"
+    dest: '{{ jira_install_location }}'
+    owner: '{{ jira_user }}'
+    group: '{{ jira_group }}'
+    copy: no
 
 - name: Get install path
   shell: ls -d {{ jira_install_location }}/atlassian-jira*
@@ -30,29 +46,40 @@
   with_items: "{{ full_path.stdout_lines }}"
 
 - name: Set ownership permissions
-  file: dest="{{ jira_install_location }}/jira" owner={{ jira_user }} group={{ jira_group }} mode=0755 recurse=yes
+  file:
+    dest: "{{ jira_install_location }}/jira"
+    owner: '{{ jira_user }}'
+    group: '{{ jira_group }}'
+    mode: 0755
+    recurse: yes
 
 - name: Create jira_home directory
-  file: path={{ jira_application_home }}/jira state=directory owner={{ jira_user }}  group={{ jira_group }}
+  file:
+    path: '{{ jira_application_home }}/jira'
+    state: directory
+    owner: '{{ jira_user }}'
+    group: '{{ jira_group }}'
 
 - name: Set jira_home in application
   lineinfile:
-     dest="{{ jira_install_location }}/jira/atlassian-jira/WEB-INF/classes/jira-application.properties"
-     regexp="^jira.home ="
-     line="jira.home = {{ jira_application_home }}/jira"
+    dest: "{{ jira_install_location }}/jira/atlassian-jira/WEB-INF/classes/jira-application.properties"
+    regexp: "^jira.home ="
+    line: "jira.home = {{ jira_application_home }}/jira"
 
 - name: Set default user for jira
   lineinfile:
-     dest="{{ jira_install_location }}/jira/bin/user.sh"
-     regexp="^JIRA_USER="
-     line="JIRA_USER={{ jira_user }}"
+    dest: "{{ jira_install_location }}/jira/bin/user.sh"
+    regexp: "^JIRA_USER="
+    line: "JIRA_USER={{ jira_user }}"
 
 - name: Set JIRA Minimum Memory
-  replace: dest={{ jira_install_location }}/jira/bin/setenv.sh
-           regexp='384m'
-           replace='{{ jira_jvm_minimum_memory }}'
+  replace:
+    dest: '{{ jira_install_location }}/jira/bin/setenv.sh'
+    regexp: '384m'
+    replace: '{{ jira_jvm_minimum_memory }}'
 
 - name: Set JIRA Maximum Memory
-  replace: dest={{ jira_install_location }}/jira/bin/setenv.sh
-           regexp='768m'
-           replace='{{ jira_jvm_maximum_memory }}'
+  replace:
+    dest: '{{ jira_install_location }}/jira/bin/setenv.sh'
+    regexp: '768m'
+    replace: '{{ jira_jvm_maximum_memory }}'

--- a/tasks/setupService.yml
+++ b/tasks/setupService.yml
@@ -1,6 +1,11 @@
 ---
 - name: Install init script
-  template: src=templates/init.j2 dest=/etc/init.d/jira owner=root group=root mode=755
+  template:
+    src: templates/init.j2
+    dest: /etc/init.d/jira
+    owner: root
+    group: root
+    mode: 0755
 
 - name: Register Service
   service: name=jira enabled=yes state=started


### PR DESCRIPTION
Good day!

I noticed use of legacy multi-line in the tasks. That's why I thought I'd edit them to native yaml, to increase readability and for more coherence to the best practices of Ansible. I verified the changes with ansible-playbook check and syntax-check, and ansible-lint. Please accept my changes.

Kind regards,

Ruben